### PR TITLE
feat: 🎸 ARManager to handle ARView code reuse and Mocking

### DIFF
--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsContentView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsContentView.swift
@@ -23,7 +23,8 @@ struct ARCardsDefaultContentView: View {
     
     func loadInitialData() {
         let cardItems = Tests.carEngineCardItems
-        let strategy = RealityComposerStrategy(cardContents: cardItems, uiImage: UIImage(named: "qrImage"), physicalWidth: 0.1, rcFile: "ExampleRC", rcScene: "ExampleScene")
+        guard let anchorImage = UIImage(named: "qrImage") else { return }
+        let strategy = RealityComposerStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.1, rcFile: "ExampleRC", rcScene: "ExampleScene")
         arModel.load(loadingStrategy: strategy)
     }
 }

--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsViewBuilderContentView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsViewBuilderContentView.swift
@@ -28,7 +28,8 @@ struct ARCardsViewBuilderContentView: View {
     
     func loadInitialData() {
         let cardItems = Tests.carEngineCardItems
-        let strategy = RealityComposerStrategy(cardContents: cardItems, uiImage: UIImage(named: "qrImage"), physicalWidth: 0.1, rcFile: "ExampleRC", rcScene: "ExampleScene")
+        guard let anchorImage = UIImage(named: "qrImage") else { return }
+        let strategy = RealityComposerStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.1, rcFile: "ExampleRC", rcScene: "ExampleScene")
         arModel.load(loadingStrategy: strategy)
     }
 }

--- a/Apps/Examples/Examples/ARCards/CardContentViews/CarEngineExampleContentView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/CarEngineExampleContentView.swift
@@ -23,7 +23,8 @@ struct CarEngineExampleContentView: View {
     
     func loadData() {
         let cardItems = Tests.carEngineCardItems
-        let strategy = RealityComposerStrategy(cardContents: cardItems, uiImage: UIImage(named: "carSticker"), physicalWidth: 0.1, rcFile: "ExampleRC", rcScene: "ExampleScene")
+        guard let anchorImage = UIImage(named: "carSticker") else { return }
+        let strategy = RealityComposerStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.15, rcFile: "ExampleRC", rcScene: "ExampleScene")
         arModel.load(loadingStrategy: strategy)
     }
 }

--- a/Sources/FioriARKit/ARCards/RealityKit/AnnotationStrategies.swift
+++ b/Sources/FioriARKit/ARCards/RealityKit/AnnotationStrategies.swift
@@ -10,68 +10,86 @@ import Foundation
 import RealityKit
 import SwiftUI
 
-/// A loading strategy that uses the RealityComposer app. After creating the Reality Composer scene, tthe entities in the scene correlate to a real world location relative to the image or object anchor. This strategy wraps the anchors that represents these locations with the CardItemModels that they correspond to in a ScreenAnnotation struct for a single source of truth. Loading the data into the ARAnnotationViewModel should be done in the onAppear method.
+/// A loading strategy that uses the RealityComposer app. After creating the Reality Composer scene, tthe entities in the scene correlate to a real world location relative to the image or object anchor.
+/// This strategy wraps the anchors that represents these locations with the CardItemModels that they correspond to in a ScreenAnnotation struct for a single source of truth.
+/// Loading the data into the ARAnnotationViewModel should be done in the onAppear method.
 ///
 /// - Parameters:
-///
-///  - cardContents: An array of **CardItem : CardItemModel** which represent what will be displayed in the default CardView
-///  - uiImage: Image to be converted to ARReferenceImage and added to ARConfiguration for discovery, can be nil if detecting an object Anchor
-///  - physicalWidth: The physical width of the image to be discovered, can be nil if detecting an object Anchor
+///  - cardContents: An array of **CardItem : `CardItemModel`** which represent what will be displayed in the default CardView
+///  - anchorImage: Image to be converted to ARReferenceImage and added to ARConfiguration for discovery, can be nil if detecting an object Anchor
+///  - physicalWidth: The width of the image in meters
 ///  - rcFile: Name of the Reality Composer File without the extension. *Note: .rcproject file, not a .reality file*
 ///  - sceneName: Name given to the scene in the Reality Composer app.
 ///
 /// ## Usage
-///
 /// ```
 /// let cardItems = [ExampleCardItem(id: 0, title_: "Hello"), ExampleCardItem(id: 1, title_: "World")]
-/// let strategy = RealityComposerStrategy(cardContents: cardItems, uiImage: UIImage(named: "qrImage"), rcFile: "ExampleRC", rcScene: "ExampleScene")
+/// guard let anchorImage = UIImage(named: "qrImage") else { return }
+/// let strategy = RealityComposerStrategy(cardContents: cardItems, anchorImage: anchorImage, rcFile: "ExampleRC", rcScene: "ExampleScene")
 /// arModel.load(loadingStrategy: strategy)
-///
 /// ```
-
 public struct RealityComposerStrategy<CardItem: CardItemModel>: AnnotationLoadingStrategy where CardItem.ID: LosslessStringConvertible {
     public var cardContents: [CardItem]
+    public var anchorImage: UIImage?
+    public var physicalWidth: CGFloat?
     public var rcFile: String
     public var rcScene: String
-    public var uiImage: UIImage?
-    public var physicalWidth: CGFloat?
     
-    public init(cardContents: [CardItem], uiImage: UIImage? = nil, physicalWidth: CGFloat? = nil, rcFile: String, rcScene: String) {
+    /// Constructor for loading annotations using an Image as an anchor with a Reality Composer scene
+    public init(cardContents: [CardItem], anchorImage: UIImage, physicalWidth: CGFloat, rcFile: String, rcScene: String) {
         self.cardContents = cardContents
-        self.uiImage = uiImage
+        self.anchorImage = anchorImage
         self.physicalWidth = physicalWidth
         self.rcFile = rcFile
         self.rcScene = rcScene
     }
     
-    public func load(with manager: ARManagement) -> [ScreenAnnotation<CardItem>] {
+    /// Constructor for loading annotations using an Object as an anchor with a Reality Composer scene
+    public init(cardContents: [CardItem], rcFile: String, rcScene: String) {
+        self.cardContents = cardContents
+        self.anchorImage = nil
+        self.physicalWidth = nil
+        self.rcFile = rcFile
+        self.rcScene = rcScene
+    }
+    
+    /// Loads the Reality Composer Scene and extracts the Entities pairing them with the data that corresponds to their ID into a list of `ScreenAnnotation`
+    public func load(with manager: ARManagement) throws -> [ScreenAnnotation<CardItem>] {
         var annotations = [ScreenAnnotation<CardItem>]()
         
         guard let scene = try? RCScanner.loadScene(rcFileName: rcFile, sceneName: rcScene) else {
-            print("Scene Failed to Load")
-            return []
+            throw LoadingStrategyError.sceneLoadingFailed
         }
         
+        // An image should use world tracking so we set the configuration to prevent automatic switching to Image Tracking
+        // Object Detection inherently uses world tracking so an automatic configuration can be used
         switch scene.anchoring.target {
         case .image:
-            guard let image = uiImage, let width = physicalWidth else { return [] }
+            guard let image = anchorImage, let width = physicalWidth else { return [] }
             manager.sceneRoot = scene
             manager.addReferenceImage(for: image, with: width)
         case .object:
-            manager.arView?.automaticallyConfigureSession = true
+            manager.setAutomaticConfiguration()
             manager.addAnchor(for: scene)
         default:
-            print("Only Image and Object anchors supported")
+            throw LoadingStrategyError.anchorTypeNotSupported
         }
         
         for cardItem in self.cardContents {
-            if let internalEntity = scene.findEntity(named: String(cardItem.id)) {
-                let annotation = ScreenAnnotation(card: cardItem)
-                annotation.setInternalEntity(with: internalEntity)
-                annotations.append(annotation)
+            guard let internalEntity = scene.findEntity(named: String(cardItem.id)) else {
+                throw LoadingStrategyError.entityNotFound(cardItem.id)
             }
+            let annotation = ScreenAnnotation(card: cardItem)
+            annotation.setInternalEntity(with: internalEntity)
+            annotations.append(annotation)
         }
         
         return annotations
     }
+}
+
+private enum LoadingStrategyError: Error {
+    case anchorTypeNotSupported
+    case entityNotFound(LosslessStringConvertible)
+    case sceneLoadingFailed
 }

--- a/Sources/FioriARKit/ARCards/RealityKit/RCScanner.swift
+++ b/Sources/FioriARKit/ARCards/RealityKit/RCScanner.swift
@@ -56,5 +56,6 @@ internal enum RCScanner {
         return scene
     }
 
+    /// A convenience class which subclasses Entity and conforms to HasAnchoring
     internal class Scene: RealityKit.Entity, RealityKit.HasAnchoring {}
 }

--- a/Sources/FioriARKit/ARCards/RealityKit/ScreenAnnotation.swift
+++ b/Sources/FioriARKit/ARCards/RealityKit/ScreenAnnotation.swift
@@ -38,6 +38,7 @@ public struct ScreenAnnotation<CardItem: CardItemModel>: Identifiable, Equatable
         self.isSelected = isSelected
     }
     
+    /// Sets the internal within the MarkerAnchor
     public func setInternalEntity(with entity: Entity) {
         self.marker.internalEnitity = entity
     }

--- a/Sources/FioriARKit/ARCards/ViewModels/ARAnnotationViewModel.swift
+++ b/Sources/FioriARKit/ARCards/ViewModels/ARAnnotationViewModel.swift
@@ -10,16 +10,13 @@ import Combine
 import RealityKit
 import SwiftUI
 
+///  ViewModel for managing an ARCards experience. Provides and sets the annotation data/anchor locations to the view and the flow for the discovery animations.
 open class ARAnnotationViewModel<CardItem: CardItemModel>: NSObject, ObservableObject, ARSessionDelegate {
     /// Manages all common functionality for the ARView
     internal var arManager: ARManagement = ARManager()
     
-    /**
-     An array of **ScreenAnnotations** which are displayed in the scene  contain the marker position and their card contents
-    
-     - The annotations internal entities within this list should be in the ARView scene.
-     - Set by the annotation loading strategy
-     */
+    /// An array of **ScreenAnnotations** which are displayed in the scene  contain the marker position and their card contents
+    /// The annotations internal entities within this list should be in the ARView scene. Set by the annotation loading strategy
     @Published public internal(set) var annotations = [ScreenAnnotation<CardItem>]()
     
     /// The ScreenAnnotation that is focused on in the scene. The CardView and MarkerView will be in their selected states
@@ -28,14 +25,12 @@ open class ARAnnotationViewModel<CardItem: CardItemModel>: NSObject, ObservableO
     /// The position of the ARAnchor thats discovered
     @Published internal var anchorPosition: CGPoint?
     
-    /**
-     When false it indicates that the Image or Object has not been discovered and the subsequent animations have finished
-    
-     - When the Image/Object Anchor is discovered there is a 3 second delay for animations to complete until the ContentView with Cards and Markers are displayed
-     */
+    /// When false it indicates that the Image or Object has not been discovered and the subsequent animations have finished
+    /// When the Image/Object Anchor is discovered there is a 3 second delay for animations to complete until the ContentView with Cards and Markers are displayed
     @Published internal var discoveryFlowHasFinished = false
     
-    /// The ARAnchor that represents the position
+    /// The ARImageAnchor or ARPlaneAnchor that is supplied by the ARSessionDelegate upon discovery of image or object in the physical world
+    /// Stores useful information such as anchor position and image/object data. In the case of image anchor it is also used to instantiate an AnchorEntity
     private var arkitAnchor: ARAnchor?
     
     override public init() {
@@ -48,7 +43,7 @@ open class ARAnnotationViewModel<CardItem: CardItemModel>: NSObject, ObservableO
     
     /// Updates scene on frame change
     /// Used to project the location of the Entities from the world space onto the screen space
-    // Potential to add a closure here for developer to add logic on frame change
+    /// Potential to add a closure here for developer to add logic on frame change
     public func updateScene(on event: SceneEvents.Update) {
         for (index, entity) in self.annotations.enumerated() {
             guard let projectedPoint = arManager.arView?.project(entity.marker.internalEnitity.position(relativeTo: nil)) else { return }
@@ -66,10 +61,11 @@ open class ARAnnotationViewModel<CardItem: CardItemModel>: NSObject, ObservableO
     
     /// Loads a strategy into the arModel and sets **annotations** member from the returned [ScreenAnnotation]
     public func load<Strategy: AnnotationLoadingStrategy>(loadingStrategy: Strategy) where CardItem == Strategy.CardItem {
-        self.annotations = loadingStrategy.load(with: self.arManager)
+        do { self.annotations = try loadingStrategy.load(with: self.arManager) } catch { print("Annotation Loading Error: \(error)") }
         self.currentAnnotation = self.annotations.first
     }
     
+    /// Sets the visibility of the Marker View for  a CardItem identified by its ID *Note: The `MarkerAnchor` still exists in the scene*
     public func setMarkerVisibility(for id: CardItem.ID, to isVisible: Bool) {
         for (index, annotation) in self.annotations.enumerated() where annotation.id == id {
             self.annotations[index].setMarkerVisibility(to: isVisible)
@@ -82,7 +78,6 @@ open class ARAnnotationViewModel<CardItem: CardItemModel>: NSObject, ObservableO
 //            if annotation.id == id { annotations[index].setCardVisibility(to: isVisible) }
 //        }
 //    }
-
     // Cards are initially set to visible
     private func showAnnotationsAfterDiscoveryFlow() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
@@ -102,6 +97,7 @@ open class ARAnnotationViewModel<CardItem: CardItemModel>: NSObject, ObservableO
 
     // MARK: ARSession Delegate
     
+    /// Tells the delegate that one or more anchors have been added to the session.
     public func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
         if let imageAnchor = anchors.compactMap({ $0 as? ARImageAnchor }).first {
             guard let root = arManager.sceneRoot else { return }
@@ -119,6 +115,7 @@ open class ARAnnotationViewModel<CardItem: CardItemModel>: NSObject, ObservableO
         }
     }
     
+    /// Provides a newly captured camera image and accompanying AR information to the delegate.
     public func session(_ session: ARSession, didUpdate frame: ARFrame) {
         guard !self.discoveryFlowHasFinished else { return }
 

--- a/Sources/FioriARKit/ARCards/ViewModels/ARManager.swift
+++ b/Sources/FioriARKit/ARCards/ViewModels/ARManager.swift
@@ -10,6 +10,16 @@ import Combine
 import RealityKit
 import SwiftUI
 
+/// Stores and manages common functional for the ARView
+///
+/// - Parameters:
+///  - arView: The RealityKit ARView which provides the scene and ARSession for the AR Experience
+///  - sceneRoot: The root for a strategy which uses a single Anchor
+///  - onSceneUpate: Closure which is called on every frame update
+///  - worldMap: Optional stored reference for a ARWorldMap
+///  - referenceImages: List of current ARReferenceImages which have been loaded into the configuration
+///  - detectionObjects: List of current ARReferenceImages which have been loaded into the configuration
+/// ```
 public class ARManager: ARManagement {
     public var arView: ARView?
     public var sceneRoot: HasAnchoring?
@@ -29,19 +39,24 @@ public class ARManager: ARManagement {
         }
     }
     
+    /// Set the configuration for the ARView's session with options
     public func configureSession(with configuration: ARConfiguration, options: ARSession.RunOptions = []) {
         self.arView?.session.run(configuration, options: options)
     }
     
+    /// Cleans up the arView which is necessary for SwiftUI navigation
     public func tearDown() {
         self.arView = nil
         self.subscription = nil
     }
 
+    /// Adds a Entity which conforms to HasAnchoring to the arView.scene
     public func addAnchor(for entity: HasAnchoring) {
         self.arView?.scene.addAnchor(entity)
     }
     
+    /// Adds an ARReferenceImage to the configuration for the session to discover
+    /// Optionally can set the configuration to ARImageTrackingConfiguration
     public func addReferenceImage(for image: UIImage, _ name: String = "", with physicalWidth: CGFloat, configuration: ARConfiguration = ARWorldTrackingConfiguration()) {
         guard let referenceImage = createReferenceImage(image, name, physicalWidth) else { return }
         self.referenceImages.insert(referenceImage)

--- a/Sources/FioriARKit/ARCards/Views/ContentViews/SingleImageARCardView.swift
+++ b/Sources/FioriARKit/ARCards/Views/ContentViews/SingleImageARCardView.swift
@@ -10,6 +10,13 @@ import SwiftUI
 /**
  Content View which displays the card and marker views after a discovery flow for a single Image in the scene after the discoveryFlowHasFinished has been set to True. Only displays the views which are set to isVisible. Cards and Markers are initially set to isVisible.
  
+  - Parameters:
+    - arModel: The ViewModel which managers the AR Experience
+    - image: The image that is provided to the ScanView which displays what should be discovered for in the physical scene for the User
+    - scanLabel: View Builder for a custom Scanning View. After the Image/Object has been discovered there is a 3 second delay until the ContentView displays Markers and Cards
+    - cardLabel: View Builder for a custom CardView
+    - markerLabel: View Builder for a custom MarkerView
+ 
  ## Usage
  ```
  // Constructor for Default ScanningView, CardView, and MarkerView
@@ -38,7 +45,8 @@ import SwiftUI
  
  func loadData() {
      let cardItems = Tests.cardItems
-     let strategy = RealityComposerStrategy(cardContents: cardItems, rcFile: "ExampleRC", rcScene: "ExampleScene")
+     guard let anchorImage = UIImage(named: "qrImage") else { return }
+     let strategy = RealityComposerStrategy(cardContents: cardItems, anchorImage: anchorImage, rcFile: "ExampleRC", rcScene: "ExampleScene")
      arModel.load(loadingStrategy: strategy)
  }
  ```

--- a/Sources/FioriARKit/ARContainer.swift
+++ b/Sources/FioriARKit/ARContainer.swift
@@ -20,32 +20,41 @@ internal struct ARContainer: UIViewRepresentable {
     func updateUIView(_ arView: ARView, context: Context) {}
 }
 
+/// The Protocol which stores the ARView an defines common functionality
 public protocol ARManagement: AnyObject {
     var arView: ARView? { get set }
     var onSceneUpate: ((SceneEvents.Update) -> Void)? { get set }
     var sceneRoot: HasAnchoring? { get set }
 
     func configureSession(with configuration: ARConfiguration, options: ARSession.RunOptions)
+    func setAutomaticConfiguration()
     func addReferenceImage(for image: UIImage, _ name: String, with physicalWidth: CGFloat, configuration: ARConfiguration)
     func addAnchor(for entity: HasAnchoring)
     func tearDown()
 }
 
 public extension ARManagement {
+    /// Set the ARView to automatically configure
+    func setAutomaticConfiguration() {
+        self.arView?.automaticallyConfigureSession = true
+    }
+    
+    /// Set the configuration for the ARView's session with options
     func configureSession(with configuration: ARConfiguration, options: ARSession.RunOptions = []) {
         self.configureSession(with: configuration, options: options)
     }
     
+    /// Adds an ARReferenceImage to the configuration for the session to discover
     func addReferenceImage(for image: UIImage, _ name: String = "", with physicalWidth: CGFloat, configuration: ARConfiguration = ARWorldTrackingConfiguration()) {
         self.addReferenceImage(for: image, name, with: physicalWidth, configuration: configuration)
     }
 }
 
+/// Protocol which defines the data a strategy needs to provide a `[ScreenAnnotation]`
 public protocol AnnotationLoadingStrategy {
     associatedtype CardItem: CardItemModel
     var cardContents: [CardItem] { get }
-    func load(with manager: ARManagement) -> [ScreenAnnotation<CardItem>]
+    func load(with manager: ARManagement) throws -> [ScreenAnnotation<CardItem>]
 }
 
 typealias AnchorID = UUID
-public typealias RealityScene = RealityKit.Entity & RealityKit.HasAnchoring


### PR DESCRIPTION
BREAKING CHANGE: 🧨 RealityComposer Strategy now needs the image and Dimension to create
ARReferenceImage

Pros:
- ARManager can handle common methods to reduce code reuse
- cache information, e.g. Reference Images and Objects (reseting configuration loses current set)
- Future implementation for ARView, e.g. ARWorldMap
- Handle control over which ARConfiguration is in use, a Reality Composer Scene can only work with automatic switching. This causes poor behavior in between scenarios that confuse ARKit for World Tracking and Image Tracking. Where we only need WorldTracking for current use cases.

Cons
- The image/object anchor data doesn't seem to be accessible from the rcproject File so this will need to be passed into the RealityComposer Strategy
- The LoadingStrategy is a public protocol and the ARManagement Protocol is referenced in it causing it to need to be public as well
