### PR TITLE
Incremental ReadMe update

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ struct FioriARKitCardsExample: View {
 
     func loadInitialData() {
         let cardItems = [ExampleCardModel(id: "WasherFluid", title_: "Recommended Washer Fluid"), ExampleCardModel(id: "OilStick", title_: "Check Oil Stick")]
+        guard let anchorImage = UIImage(named: "qrImage") else { return }
         let loadingStrategy = RealityComposerStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.1, rcFile: "realityComposerFileName", rcScene: "sceneName")
         arModel.load(loadingStrategy: loadingStrategy)
     }


### PR DESCRIPTION
I have information that could also be added to the readme as other sections such as an appendix, a different mark down file, or GitHub Pages:

- Evolution: Such as roadmap for future Annotation Authoring, e.g. Edit Mode, ML Recognition
- Term Glossary: The nomenclature for platform specific and agnostic terms to reduce confusion
- The background content could be moved to this as well

Any thoughts on which would be preferred if this info could be found useful on the GitHub?