### PR TITLE
feat: 🎸 Strategy To load a Reality File URL Directly

### DIFF
--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		2C4C71A72643698000B462A9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2C4C71A62643698000B462A9 /* Preview Assets.xcassets */; };
 		2C4C71B126436A5C00B462A9 /* ARCardsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4C71B026436A5C00B462A9 /* ARCardsContentView.swift */; };
 		2C4C71B526436ADC00B462A9 /* ARCardsViewBuilderContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4C71B426436ADC00B462A9 /* ARCardsViewBuilderContentView.swift */; };
+		2C5225B3267C4CC70089A062 /* ARCardsRealityFileLoadingContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5225B2267C4CC70089A062 /* ARCardsRealityFileLoadingContentView.swift */; };
+		2C5225B5267C57D00089A062 /* FileManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5225B4267C57D00089A062 /* FileManager+Extensions.swift */; };
 		2C6DDE5E2644CCD60093AA6B /* FioriARKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2C6DDE5D2644CCD60093AA6B /* FioriARKit */; };
 		2C9371282644D3C3001932D1 /* DownloadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9371272644D3C3001932D1 /* DownloadsView.swift */; };
 		2CDD909826437D630076150D /* ExampleCardItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDD909726437D630076150D /* ExampleCardItem.swift */; };
@@ -38,6 +40,8 @@
 		2C4C71B026436A5C00B462A9 /* ARCardsContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARCardsContentView.swift; sourceTree = "<group>"; };
 		2C4C71B426436ADC00B462A9 /* ARCardsViewBuilderContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARCardsViewBuilderContentView.swift; sourceTree = "<group>"; };
 		2C4C71C026436E2400B462A9 /* cloud-sdk-ios-fioriarkit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "cloud-sdk-ios-fioriarkit"; path = ../..; sourceTree = "<group>"; };
+		2C5225B2267C4CC70089A062 /* ARCardsRealityFileLoadingContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARCardsRealityFileLoadingContentView.swift; sourceTree = "<group>"; };
+		2C5225B4267C57D00089A062 /* FileManager+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Extensions.swift"; sourceTree = "<group>"; };
 		2C9371272644D3C3001932D1 /* DownloadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsView.swift; sourceTree = "<group>"; };
 		2CDD909726437D630076150D /* ExampleCardItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleCardItem.swift; sourceTree = "<group>"; };
 		2CDD909A26437E7A0076150D /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
@@ -79,6 +83,7 @@
 				2C4C71B426436ADC00B462A9 /* ARCardsViewBuilderContentView.swift */,
 				2C4C71B026436A5C00B462A9 /* ARCardsContentView.swift */,
 				2C48248B264DC33300E230E6 /* CarEngineExampleContentView.swift */,
+				2C5225B2267C4CC70089A062 /* ARCardsRealityFileLoadingContentView.swift */,
 			);
 			path = CardContentViews;
 			sourceTree = "<group>";
@@ -97,6 +102,7 @@
 			children = (
 				2CDD909A26437E7A0076150D /* Tests.swift */,
 				2C9371272644D3C3001932D1 /* DownloadsView.swift */,
+				2C5225B4267C57D00089A062 /* FileManager+Extensions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -243,6 +249,8 @@
 				2C3C67602674006B00B2B243 /* CarEngineRC1.rcproject in Sources */,
 				2C4C71A22643697F00B462A9 /* ContentView.swift in Sources */,
 				2C4C71B126436A5C00B462A9 /* ARCardsContentView.swift in Sources */,
+				2C5225B5267C57D00089A062 /* FileManager+Extensions.swift in Sources */,
+				2C5225B3267C4CC70089A062 /* ARCardsRealityFileLoadingContentView.swift in Sources */,
 				2C48248C264DC33300E230E6 /* CarEngineExampleContentView.swift in Sources */,
 				2C4C71B526436ADC00B462A9 /* ARCardsViewBuilderContentView.swift in Sources */,
 				2C4C71A02643697F00B462A9 /* ExamplesApp.swift in Sources */,

--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsRealityFileLoadingContentView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsRealityFileLoadingContentView.swift
@@ -1,0 +1,31 @@
+//
+//  ARCardsRealityFileloadingContentView.swift
+//  Examples
+//
+//  Created by O'Brien, Patrick on 6/17/21.
+//
+
+import FioriARKit
+import SwiftUI
+
+struct ARCardsRealityFileLoadingContentView: View {
+    @StateObject var arModel = ARAnnotationViewModel<StringIdentifyingCardItem>()
+    
+    var body: some View {
+        SingleImageARCardView(arModel: arModel,
+                              image: Image("qrImage"),
+                              cardAction: { id in
+                                  // set the card action for id corresponding to the CardItemModel
+                                  print(id)
+                              })
+            .onAppear(perform: loadInitialDataFromRealityFile)
+    }
+
+    func loadInitialDataFromRealityFile() {
+        let cardItems = Tests.carEngineCardItems
+        let realityFilePath = FileManager.default.getDocumentsDirectory().appendingPathComponent(FileManager.realityFiles).appendingPathComponent("ExampleRC.reality")
+        guard let anchorImage = UIImage(named: "qrImage") else { return }
+        let strategy = RealityFileStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.1, realityFilePath: realityFilePath, rcScene: "ExampleScene")
+        arModel.load(loadingStrategy: strategy)
+    }
+}

--- a/Apps/Examples/Examples/ARCards/Utils/FileManager+Extensions.swift
+++ b/Apps/Examples/Examples/ARCards/Utils/FileManager+Extensions.swift
@@ -1,0 +1,43 @@
+//
+//  FileManager+Extensions.swift
+//  Examples
+//
+//  Created by O'Brien, Patrick on 6/17/21.
+//
+
+import Foundation
+
+extension FileManager {
+    static let realityFiles = "RealityFiles"
+    static let usdzFiles = "USDZFiles"
+    
+    func getDocumentsDirectory() -> URL {
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
+        let documentsDirectory = paths[0]
+        return URL(string: documentsDirectory)!
+    }
+    
+    @discardableResult
+    func makeDirectoryInDocumentsDirectory(_ directory: String) -> URL {
+        let dataPath = self.getDocumentsDirectory().appendingPathComponent(directory)
+        
+        if !FileManager.default.fileExists(atPath: dataPath.path) {
+            do {
+                try FileManager.default.createDirectory(atPath: dataPath.path, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+        return dataPath
+    }
+    
+    func saveDataToDirectory(_ saveDirectory: URL, saveData: Data) {
+        guard let safeDirectory = URL(string: "file://" + saveDirectory.path) else { print("Safe Directory Error"); return }
+        
+        do {
+            try saveData.write(to: safeDirectory)
+        } catch {
+            print("File Not Saved: \(error)")
+        }
+    }
+}

--- a/Apps/Examples/Examples/ContentView.swift
+++ b/Apps/Examples/Examples/ContentView.swift
@@ -23,6 +23,10 @@ struct ContentView: View {
                     Text("2016 Engine Example")
                 }
                 
+                NavigationLink(destination: ARCardsRealityFileLoadingContentView()) {
+                    Text("Reality File Example")
+                }
+                
                 NavigationLink(destination: DownloadsView()) {
                     Text("Download Image Anchors")
                 }

--- a/Apps/Examples/Examples/ExamplesApp.swift
+++ b/Apps/Examples/Examples/ExamplesApp.swift
@@ -9,9 +9,29 @@ import SwiftUI
 
 @main
 struct ExamplesApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
+    }
+}
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        // Create Directories to store RealityFiles and USDZ Files in Documents Directory
+        let realityDir = FileManager.default.makeDirectoryInDocumentsDirectory(FileManager.realityFiles)
+        _ = FileManager.default.makeDirectoryInDocumentsDirectory(FileManager.usdzFiles)
+        
+        // Extract Reality File from rcprojects in the app bundle
+        // Save that Reality File to Documents/RealityFiles/
+        guard let extractExampleURL = Foundation.Bundle(for: ExampleRC.ExampleScene.self).url(forResource: "ExampleRC", withExtension: "reality"),
+              let exampleRCData = try? Data(contentsOf: extractExampleURL) else { return true }
+        
+        let saveExampleURL = realityDir.appendingPathComponent("ExampleRC.reality")
+        FileManager.default.saveDataToDirectory(saveExampleURL, saveData: exampleRCData)
+        
+        return true
     }
 }

--- a/Sources/FioriARKit/ARCards/RealityKit/RCScanner.swift
+++ b/Sources/FioriARKit/ARCards/RealityKit/RCScanner.swift
@@ -27,6 +27,12 @@ internal enum RCScanner {
         let anchorEntity = try RCScanner.Scene.loadAnchor(contentsOf: realityFileSceneURL)
         return self.createScene(from: anchorEntity)
     }
+    
+    internal static func loadSceneFromRealityFile(realityFileURL: URL, sceneName: String) throws -> RCScanner.Scene {
+        let realityFileSceneURL = realityFileURL.appendingPathComponent(sceneName, isDirectory: false)
+        let anchorEntity = try RCScanner.Scene.loadAnchor(contentsOf: realityFileSceneURL)
+        return self.createScene(from: anchorEntity)
+    }
 
     internal static func loadSceneAsync(rcFileName: String, completion: @escaping (Swift.Result<RCScanner.Scene, Swift.Error>) -> Void) {
         guard let realityFileURL = Foundation.Bundle(for: RCScanner.Scene.self).url(forResource: rcFileName, withExtension: "reality") else {

--- a/Sources/FioriARKit/ARCards/RealityKit/RealityFileStrategy.swift
+++ b/Sources/FioriARKit/ARCards/RealityKit/RealityFileStrategy.swift
@@ -1,0 +1,88 @@
+//
+//  AnnotationStrategies.swift
+//
+//
+//  Created by O'Brien, Patrick on 3/2/21.
+//
+
+import ARKit
+import Foundation
+import RealityKit
+import SwiftUI
+
+/// A loading strategy that uses the RealityComposer app. After creating the Reality Composer scene, tthe entities in the scene correlate to a real world location relative to the image or object anchor.
+/// This strategy wraps the anchors that represents these locations with the CardItemModels that they correspond to in a ScreenAnnotation struct for a single source of truth.
+/// Loading the data into the ARAnnotationViewModel should be done in the onAppear method.
+///
+/// - Parameters:
+///  - cardContents: An array of **CardItem : `CardItemModel`** which represent what will be displayed in the default CardView
+///  - anchorImage: Image to be converted to ARReferenceImage and added to ARConfiguration for discovery, can be nil if detecting an object Anchor
+///  - physicalWidth: The width of the image in meters
+///  - realityFileURL: URL path to a .reality file that makes contains the scene, exported from Reality Composer
+///  - sceneName: Name given to the scene in the Reality Composer app.
+///
+/// ## Usage
+/// ```
+/// let cardItems = [ExampleCardItem(id: 0, title_: "Hello"), ExampleCardItem(id: 1, title_: "World")]
+/// guard let anchorImage = UIImage(named: "qrImage") else { return }
+/// let realityFilePath = FileManager.default.getDocumentsDirectory().appendingPathComponent(FileManager.realityFiles).appendingPathComponent("ExampleRC.reality")
+/// let strategy = RealityFileStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.1, realityFilePath: realityFilePath, rcScene: "ExampleScene")
+/// arModel.load(loadingStrategy: strategy)
+/// ```
+public struct RealityFileStrategy<CardItem: CardItemModel>: AnnotationLoadingStrategy where CardItem.ID: LosslessStringConvertible {
+    public var cardContents: [CardItem]
+    public var anchorImage: UIImage?
+    public var physicalWidth: CGFloat?
+    public var realityFilePath: URL
+    public var rcScene: String
+    
+    /// Constructor for loading annotations using an Image as an anchor with a Reality Composer scene
+    /// If Object Anchor is used anchorImage and PhysicalWidth are ignored and can be set to nil
+    public init(cardContents: [CardItem], anchorImage: UIImage? = nil, physicalWidth: CGFloat? = nil, realityFilePath: URL, rcScene: String) {
+        self.cardContents = cardContents
+        self.anchorImage = anchorImage
+        self.physicalWidth = physicalWidth
+        self.realityFilePath = realityFilePath
+        self.rcScene = rcScene
+    }
+    
+    /// Loads the Reality Composer Scene and extracts the Entities pairing them with the data that corresponds to their ID into a list of `ScreenAnnotation`
+    public func load(with manager: ARManagement) throws -> [ScreenAnnotation<CardItem>] {
+        var annotations = [ScreenAnnotation<CardItem>]()
+        
+        guard let scene = try? RCScanner.loadSceneFromRealityFile(realityFileURL: realityFilePath, sceneName: rcScene) else {
+            throw LoadingStrategyError.sceneLoadingFailed
+        }
+        
+        // An image should use world tracking so we set the configuration to prevent automatic switching to Image Tracking
+        // Object Detection inherently uses world tracking so an automatic configuration can be used
+        switch scene.anchoring.target {
+        case .image:
+            guard let image = anchorImage, let width = physicalWidth else { return [] }
+            manager.sceneRoot = scene
+            manager.addReferenceImage(for: image, with: width)
+        case .object:
+            manager.setAutomaticConfiguration()
+            manager.addAnchor(for: scene)
+        default:
+            throw LoadingStrategyError.anchorTypeNotSupported
+        }
+        
+        for cardItem in self.cardContents {
+            guard let internalEntity = scene.findEntity(named: String(cardItem.id)) else {
+                throw LoadingStrategyError.entityNotFound(cardItem.id)
+            }
+            let annotation = ScreenAnnotation(card: cardItem)
+            annotation.setInternalEntity(with: internalEntity)
+            annotations.append(annotation)
+        }
+        
+        return annotations
+    }
+}
+
+private enum LoadingStrategyError: Error {
+    case anchorTypeNotSupported
+    case entityNotFound(LosslessStringConvertible)
+    case sceneLoadingFailed
+}


### PR DESCRIPTION
- Logic in sample app to Extract Reality File from the app bundle and place it in Documents Directory
- New Reality File Strategy can load Reality File from a URL
- This will enable the reality File to be sourced from URL and now does not need to be bundled from Xcode

TODO:
- If JSON proposal is accepted then create an init to load from a JSON File