### PR TITLE
feat: 🎸 Proposal: Loading from Reality File and SceneLoadable

### DIFF
--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		2C4C71B526436ADC00B462A9 /* ARCardsViewBuilderContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4C71B426436ADC00B462A9 /* ARCardsViewBuilderContentView.swift */; };
 		2C5225B1267BF28A0089A062 /* ARCardsJSONLoadingContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5225B0267BF28A0089A062 /* ARCardsJSONLoadingContentView.swift */; };
 		2C5225B7267CF7980089A062 /* Tests.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C5225B6267CF7980089A062 /* Tests.json */; };
+		2C554AE22681189B007784D6 /* ARCardsRealityFileLoadingContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C554AE12681189B007784D6 /* ARCardsRealityFileLoadingContentView.swift */; };
+		2C554AE4268118E0007784D6 /* FileManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C554AE3268118E0007784D6 /* FileManager+Extensions.swift */; };
 		2C6DDE5E2644CCD60093AA6B /* FioriARKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2C6DDE5D2644CCD60093AA6B /* FioriARKit */; };
 		2C9371282644D3C3001932D1 /* DownloadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9371272644D3C3001932D1 /* DownloadsView.swift */; };
 		2CDD909826437D630076150D /* ExampleCardItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDD909726437D630076150D /* ExampleCardItem.swift */; };
@@ -42,6 +44,8 @@
 		2C4C71C026436E2400B462A9 /* cloud-sdk-ios-fioriarkit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "cloud-sdk-ios-fioriarkit"; path = ../..; sourceTree = "<group>"; };
 		2C5225B0267BF28A0089A062 /* ARCardsJSONLoadingContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARCardsJSONLoadingContentView.swift; sourceTree = "<group>"; };
 		2C5225B6267CF7980089A062 /* Tests.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Tests.json; sourceTree = "<group>"; };
+		2C554AE12681189B007784D6 /* ARCardsRealityFileLoadingContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARCardsRealityFileLoadingContentView.swift; sourceTree = "<group>"; };
+		2C554AE3268118E0007784D6 /* FileManager+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Extensions.swift"; sourceTree = "<group>"; };
 		2C9371272644D3C3001932D1 /* DownloadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsView.swift; sourceTree = "<group>"; };
 		2CDD909726437D630076150D /* ExampleCardItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleCardItem.swift; sourceTree = "<group>"; };
 		2CDD909A26437E7A0076150D /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
@@ -84,6 +88,7 @@
 				2C4C71B026436A5C00B462A9 /* ARCardsContentView.swift */,
 				2C48248B264DC33300E230E6 /* CarEngineExampleContentView.swift */,
 				2C5225B0267BF28A0089A062 /* ARCardsJSONLoadingContentView.swift */,
+				2C554AE12681189B007784D6 /* ARCardsRealityFileLoadingContentView.swift */,
 			);
 			path = CardContentViews;
 			sourceTree = "<group>";
@@ -103,6 +108,7 @@
 				2C5225B6267CF7980089A062 /* Tests.json */,
 				2CDD909A26437E7A0076150D /* Tests.swift */,
 				2C9371272644D3C3001932D1 /* DownloadsView.swift */,
+				2C554AE3268118E0007784D6 /* FileManager+Extensions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -248,7 +254,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				2C3C67602674006B00B2B243 /* CarEngineRC1.rcproject in Sources */,
+				2C554AE4268118E0007784D6 /* FileManager+Extensions.swift in Sources */,
 				2C4C71A22643697F00B462A9 /* ContentView.swift in Sources */,
+				2C554AE22681189B007784D6 /* ARCardsRealityFileLoadingContentView.swift in Sources */,
 				2C4C71B126436A5C00B462A9 /* ARCardsContentView.swift in Sources */,
 				2C5225B1267BF28A0089A062 /* ARCardsJSONLoadingContentView.swift in Sources */,
 				2C48248C264DC33300E230E6 /* CarEngineExampleContentView.swift in Sources */,

--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsJSONLoadingContentView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsJSONLoadingContentView.swift
@@ -22,11 +22,12 @@ struct ARCardsJSONLoadingContentView: View {
     }
     
     func loadInitialData() {
+        let realityFilePath = FileManager.default.getDocumentsDirectory().appendingPathComponent(FileManager.realityFiles).appendingPathComponent("ExampleRC.reality")
         guard let anchorImage = UIImage(named: "qrImage"), let url = Bundle.main.url(forResource: "Tests", withExtension: "json") else { return }
         
         do {
             let jsonData = try Data(contentsOf: url)
-            let strategy = try RealityComposerStrategy(jsonData: jsonData, anchorImage: anchorImage, physicalWidth: 0.1, rcFile: "ExampleRC", rcScene: "ExampleScene")
+            let strategy = try RealityFileStrategy(jsonData: jsonData, anchorImage: anchorImage, physicalWidth: 0.1, realityFilePath: realityFilePath, rcScene: "ExampleScene")
             arModel.load(loadingStrategy: strategy)
         } catch {
             print(error)

--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsRealityFileLoadingContentView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsRealityFileLoadingContentView.swift
@@ -1,14 +1,14 @@
 //
-//  ARCardsDefaultContentView.swift
+//  ARCardsRealityFileLoadingContentView.swift
 //  Examples
 //
-//  Created by O'Brien, Patrick on 5/5/21.
+//  Created by O'Brien, Patrick on 6/21/21.
 //
 
 import FioriARKit
 import SwiftUI
 
-struct ARCardsDefaultContentView: View {
+struct ARCardsRealityFileLoadingContentView: View {
     @StateObject var arModel = ARAnnotationViewModel<StringIdentifyingCardItem>()
     
     var body: some View {
@@ -18,13 +18,14 @@ struct ARCardsDefaultContentView: View {
                                   // set the card action for id corresponding to the CardItemModel
                                   print(id)
                               })
-            .onAppear(perform: loadInitialData)
+            .onAppear(perform: loadInitialDataFromRealityFile)
     }
-    
-    func loadInitialData() {
+
+    func loadInitialDataFromRealityFile() {
         let cardItems = Tests.carEngineCardItems
+        let realityFilePath = FileManager.default.getDocumentsDirectory().appendingPathComponent(FileManager.realityFiles).appendingPathComponent("ExampleRC.reality")
         guard let anchorImage = UIImage(named: "qrImage") else { return }
-        let strategy = RCProjectStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.1, rcFile: "ExampleRC", rcScene: "ExampleScene")
+        let strategy = RealityFileStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.1, realityFilePath: realityFilePath, rcScene: "ExampleScene")
         arModel.load(loadingStrategy: strategy)
     }
 }

--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsViewBuilderContentView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsViewBuilderContentView.swift
@@ -29,7 +29,7 @@ struct ARCardsViewBuilderContentView: View {
     func loadInitialData() {
         let cardItems = Tests.carEngineCardItems
         guard let anchorImage = UIImage(named: "qrImage") else { return }
-        let strategy = RealityComposerStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.1, rcFile: "ExampleRC", rcScene: "ExampleScene")
+        let strategy = RCProjectStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.1, rcFile: "ExampleRC", rcScene: "ExampleScene")
         arModel.load(loadingStrategy: strategy)
     }
 }

--- a/Apps/Examples/Examples/ARCards/CardContentViews/CarEngineExampleContentView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/CarEngineExampleContentView.swift
@@ -24,7 +24,7 @@ struct CarEngineExampleContentView: View {
     func loadData() {
         let cardItems = Tests.carEngineCardItems
         guard let anchorImage = UIImage(named: "carSticker") else { return }
-        let strategy = RealityComposerStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.15, rcFile: "CarEngineRC1", rcScene: "EngineScene")
+        let strategy = RCProjectStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.15, rcFile: "CarEngineRC1", rcScene: "EngineScene")
         arModel.load(loadingStrategy: strategy)
     }
 }

--- a/Apps/Examples/Examples/ARCards/Utils/FileManager+Extensions.swift
+++ b/Apps/Examples/Examples/ARCards/Utils/FileManager+Extensions.swift
@@ -1,0 +1,45 @@
+//
+//  FileManager+Extensions.swift
+//  Examples
+//
+//  Created by O'Brien, Patrick on 6/21/21.
+//
+
+import Foundation
+
+extension FileManager {
+    static let realityFiles = "RealityFiles"
+    static let usdzFiles = "USDZFiles"
+    
+    func getDocumentsDirectory() -> URL {
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
+        let documentsDirectory = paths[0]
+        return URL(string: documentsDirectory)!
+    }
+    
+    @discardableResult
+    func makeDirectoryInDocumentsDirectory(_ directory: String) -> URL {
+        let dataPath = self.getDocumentsDirectory().appendingPathComponent(directory)
+        
+        if !FileManager.default.fileExists(atPath: dataPath.path) {
+            do {
+                try FileManager.default.createDirectory(atPath: dataPath.path, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+        return dataPath
+    }
+    
+    func saveDataToDirectory(_ absoluteDirectory: URL, saveData: Data) {
+        guard let absoluteDirectory = URL(string: "file://" + absoluteDirectory.path) else { print("Safe Directory Error"); return }
+        
+        do {
+            if !FileManager.default.fileExists(atPath: absoluteDirectory.path) {
+                try saveData.write(to: absoluteDirectory)
+            }
+        } catch {
+            print("File Not Saved: \(error)")
+        }
+    }
+}

--- a/Apps/Examples/Examples/ContentView.swift
+++ b/Apps/Examples/Examples/ContentView.swift
@@ -27,6 +27,10 @@ struct ContentView: View {
                     Text("JSON Decoding Example")
                 }
                 
+                NavigationLink(destination: ARCardsRealityFileLoadingContentView()) {
+                    Text("Reality File Example")
+                }
+                
                 NavigationLink(destination: DownloadsView()) {
                     Text("Download Image Anchors")
                 }

--- a/Apps/Examples/Examples/ExamplesApp.swift
+++ b/Apps/Examples/Examples/ExamplesApp.swift
@@ -9,9 +9,30 @@ import SwiftUI
 
 @main
 struct ExamplesApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
+    }
+}
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        // Create Directories to store RealityFiles and USDZ Files in Documents Directory
+        let realityDir = FileManager.default.makeDirectoryInDocumentsDirectory(FileManager.realityFiles)
+        _ = FileManager.default.makeDirectoryInDocumentsDirectory(FileManager.usdzFiles)
+        
+        // Extract Reality File from rcprojects in the app bundle
+        // Turn the path file into Data
+        guard let extractExampleURL = Foundation.Bundle(for: ExampleRC.ExampleScene.self).url(forResource: "ExampleRC", withExtension: "reality"),
+              let exampleRCData = try? Data(contentsOf: extractExampleURL) else { return true }
+        
+        // Save that Reality File to Documents/RealityFiles/
+        let saveExampleURL = realityDir.appendingPathComponent("ExampleRC.reality")
+        FileManager.default.saveDataToDirectory(saveExampleURL, saveData: exampleRCData)
+        
+        return true
     }
 }

--- a/Sources/FioriARKit/ARCards/RealityKit/RCScanner.swift
+++ b/Sources/FioriARKit/ARCards/RealityKit/RCScanner.swift
@@ -27,6 +27,12 @@ internal enum RCScanner {
         let anchorEntity = try RCScanner.Scene.loadAnchor(contentsOf: realityFileSceneURL)
         return self.createScene(from: anchorEntity)
     }
+    
+    internal static func loadSceneFromRealityFile(realityFileURL: URL, sceneName: String) throws -> RCScanner.Scene {
+        let realityFileSceneURL = realityFileURL.appendingPathComponent(sceneName, isDirectory: false)
+        let anchorEntity = try RCScanner.Scene.loadAnchor(contentsOf: realityFileSceneURL)
+        return self.createScene(from: anchorEntity)
+    }
 
     internal static func loadSceneAsync(rcFileName: String, completion: @escaping (Swift.Result<RCScanner.Scene, Swift.Error>) -> Void) {
         guard let realityFileURL = Foundation.Bundle(for: RCScanner.Scene.self).url(forResource: rcFileName, withExtension: "reality") else {

--- a/Sources/FioriARKit/ARCards/RealityKit/RealityFileStrategy.swift
+++ b/Sources/FioriARKit/ARCards/RealityKit/RealityFileStrategy.swift
@@ -1,0 +1,94 @@
+//
+//  RealityFileStrategy.swift
+//
+//
+//  Created by O'Brien, Patrick on 6/21/21.
+//
+
+import ARKit
+import Foundation
+import RealityKit
+import SwiftUI
+
+/// A loading strategy that uses the RealityComposer app. After creating the Reality Composer scene, the entities in the scene correlate to a real world location relative to the image or object anchor.
+/// This strategy wraps the anchors that represents these locations with the CardItemModels that they correspond to in a ScreenAnnotation struct for a single source of truth.
+/// Loading the data into the ARAnnotationViewModel should be done in the onAppear method.
+///
+/// - Parameters:
+///  - cardContents: An array of **CardItem : `CardItemModel`** which represent what will be displayed in the default CardView
+///  - anchorImage: Image to be converted to ARReferenceImage and added to ARConfiguration for discovery, can be nil if detecting an object Anchor
+///  - physicalWidth: The width of the image in meters
+///  - realityFileURL: URL path to a .reality file that makes contains the scene, exported from Reality Composer
+///  - sceneName: Name given to the scene in the Reality Composer app.
+///
+/// ## Usage
+/// ```
+/// let cardItems = [ExampleCardItem(id: 0, title_: "Hello"), ExampleCardItem(id: 1, title_: "World")]
+/// guard let anchorImage = UIImage(named: "qrImage") else { return }
+/// let realityFilePath = FileManager.default.getDocumentsDirectory().appendingPathComponent(FileManager.realityFiles).appendingPathComponent("ExampleRC.reality")
+/// let strategy = RealityFileStrategy(cardContents: cardItems, anchorImage: anchorImage, physicalWidth: 0.1, realityFilePath: realityFilePath, rcScene: "ExampleScene")
+/// arModel.load(loadingStrategy: strategy)
+/// ```
+public struct RealityFileStrategy<CardItem: CardItemModel>: AnnotationLoadingStrategy, SceneLoadable where CardItem.ID: LosslessStringConvertible {
+    public var cardContents: [CardItem]
+    public var anchorImage: UIImage?
+    public var physicalWidth: CGFloat?
+    public var realityFilePath: URL
+    public var rcScene: String
+    
+    /// Constructor for loading annotations using an Image as an anchor with a Reality Composer scene
+    /// If Object Anchor is used anchorImage and PhysicalWidth are ignored and can be set to nil
+    public init(cardContents: [CardItem], anchorImage: UIImage? = nil, physicalWidth: CGFloat? = nil, realityFilePath: URL, rcScene: String) {
+        self.cardContents = cardContents
+        self.anchorImage = anchorImage
+        self.physicalWidth = physicalWidth
+        self.realityFilePath = realityFilePath
+        self.rcScene = rcScene
+    }
+    
+    /**
+     Constructor for loading annotations using Data from a JSON Array
+        JSON key/value::
+         "id": String,
+         "title": String,
+         "descriptionText": String?,
+         "detailImage": Data?, // base64 encoding of Image
+         "actionText": String?,
+         "icon": String? // systemName of SFSymbol
+     
+        Example:
+        [
+         {
+             "id": "WasherFluid",
+             "title": "Recommended Washer Fluid",
+             "descriptionText": "Rain X",
+             "detailImage": null,
+             "actionText": null,
+             "icon": null
+         },
+         {
+             "id": "Coolant",
+             "title": "Genuine Coolant",
+             "descriptionText": "Price: 20.99",
+             "detailImage": "iVBORw0KGgoAAAANSUhE...",
+             "actionText": "Order",
+             "icon": "cart.fill"
+         }
+        ]
+     */
+    public init(jsonData: Data, anchorImage: UIImage? = nil, physicalWidth: CGFloat? = nil, realityFilePath: URL, rcScene: String) throws where CardItem == DecodableCardItem {
+        self.cardContents = try JSONDecoder().decode([DecodableCardItem].self, from: jsonData)
+        self.anchorImage = anchorImage
+        self.physicalWidth = physicalWidth
+        self.realityFilePath = realityFilePath
+        self.rcScene = rcScene
+    }
+    
+    /// Loads the Reality Files Scene and extracts the Entities pairing them with the data that corresponds to their ID into a list of `ScreenAnnotation`
+    public func load(with manager: ARManagement) throws -> [ScreenAnnotation<CardItem>] {
+        let scene = try RCScanner.loadSceneFromRealityFile(realityFileURL: self.realityFilePath, sceneName: self.rcScene)
+        let annotations = try syncCardContentsWithScene(manager: manager, anchorImage: anchorImage, physicalWidth: physicalWidth, scene: scene, cardContents: cardContents)
+        
+        return annotations
+    }
+}


### PR DESCRIPTION
BREAKING CHANGE: 🧨 Renaming Loading Strategy

I created a new PR because there were complex merge conflicts in the xcodeproj file. Git was confusing a new file in the other PR and the most recent merged PR to be the same file.

- Proposal: Consolidating the common code that syncs the card contents and the hierarchy of a scene into a Protocol. This simplifies the strategies that use it.
- Proposal: Rename the RealityComposerStrategy to RCProjectStrategy since other strategies will use Reality Composer
- Implementation for loading a reality file from a URL. Changes made to the Examples app to store a reality file in its documents directory to retrieve from.