### PR TITLE
feat: 🎸 Refactored ARManager so FioriARKit is compatible with the simulator

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .target(
             name: "FioriARKit",
             dependencies: ["FioriSwiftUI"],
-            resources: [.process("Resources")]
+            resources: [.process("ARCards/Resources")]
         ),
         .testTarget(
             name: "FioriARKitTests",

--- a/Sources/FioriARKit/ARCards/RealityKit/LoadingStrategies/RCProjectStrategy.swift
+++ b/Sources/FioriARKit/ARCards/RealityKit/LoadingStrategies/RCProjectStrategy.swift
@@ -86,7 +86,7 @@ public struct RCProjectStrategy<CardItem: CardItemModel>: AnnotationLoadingStrat
     }
     
     /// Loads the Reality Composer Scene and extracts the Entities pairing them with the data that corresponds to their ID into a list of `ScreenAnnotation`
-    public func load(with manager: ARManagement) throws -> [ScreenAnnotation<CardItem>] {
+    public func load(with manager: ARManager) throws -> [ScreenAnnotation<CardItem>] {
         let scene = try RCScanner.loadScene(rcFileName: self.rcFile, sceneName: self.rcScene)
         let annotations = try syncCardContentsWithScene(manager: manager, anchorImage: anchorImage, physicalWidth: physicalWidth, scene: scene, cardContents: cardContents)
         

--- a/Sources/FioriARKit/ARCards/RealityKit/LoadingStrategies/RealityFileStrategy.swift
+++ b/Sources/FioriARKit/ARCards/RealityKit/LoadingStrategies/RealityFileStrategy.swift
@@ -85,7 +85,7 @@ public struct RealityFileStrategy<CardItem: CardItemModel>: AnnotationLoadingStr
     }
     
     /// Loads the Reality Files Scene and extracts the Entities pairing them with the data that corresponds to their ID into a list of `ScreenAnnotation`
-    public func load(with manager: ARManagement) throws -> [ScreenAnnotation<CardItem>] {
+    public func load(with manager: ARManager) throws -> [ScreenAnnotation<CardItem>] {
         let scene = try RCScanner.loadSceneFromRealityFile(realityFileURL: self.realityFilePath, sceneName: self.rcScene)
         let annotations = try syncCardContentsWithScene(manager: manager, anchorImage: anchorImage, physicalWidth: physicalWidth, scene: scene, cardContents: cardContents)
         

--- a/Sources/FioriARKit/ARCards/RealityKit/LoadingStrategies/UsdzFileStrategy.swift
+++ b/Sources/FioriARKit/ARCards/RealityKit/LoadingStrategies/UsdzFileStrategy.swift
@@ -81,7 +81,7 @@ public struct UsdzFileStrategy<CardItem: CardItemModel>: AnnotationLoadingStrate
     }
     
     /// Loads the USDZ Files Scene and extracts the Entities pairing them with the data that corresponds to their ID into a list of `ScreenAnnotation`
-    public func load(with manager: ARManagement) throws -> [ScreenAnnotation<CardItem>] {
+    public func load(with manager: ARManager) throws -> [ScreenAnnotation<CardItem>] {
         let scene = try RCScanner.loadSceneFromUsdzFile(usdzFileURL: self.usdzFilePath)
         let annotations = try syncCardContentsWithScene(manager: manager, anchorImage: anchorImage, physicalWidth: physicalWidth, scene: scene, cardContents: cardContents)
         

--- a/Sources/FioriARKit/ARContainer.swift
+++ b/Sources/FioriARKit/ARContainer.swift
@@ -11,7 +11,7 @@ import RealityKit
 import SwiftUI
 
 internal struct ARContainer: UIViewRepresentable {
-    var arStorage: ARManagement
+    var arStorage: ARManager
     
     func makeUIView(context: Context) -> ARView {
         self.arStorage.arView ?? ARView(frame: .zero)
@@ -20,47 +20,17 @@ internal struct ARContainer: UIViewRepresentable {
     func updateUIView(_ arView: ARView, context: Context) {}
 }
 
-/// The Protocol which stores the ARView an defines common functionality
-public protocol ARManagement: AnyObject {
-    var arView: ARView? { get set }
-    var onSceneUpate: ((SceneEvents.Update) -> Void)? { get set }
-    var sceneRoot: HasAnchoring? { get set }
-
-    func configureSession(with configuration: ARConfiguration, options: ARSession.RunOptions)
-    func setAutomaticConfiguration()
-    func addReferenceImage(for image: UIImage, _ name: String, with physicalWidth: CGFloat, configuration: ARConfiguration)
-    func addAnchor(for entity: HasAnchoring)
-    func tearDown()
-}
-
-public extension ARManagement {
-    /// Set the ARView to automatically configure
-    func setAutomaticConfiguration() {
-        self.arView?.automaticallyConfigureSession = true
-    }
-    
-    /// Set the configuration for the ARView's session with options
-    func configureSession(with configuration: ARConfiguration, options: ARSession.RunOptions = []) {
-        self.configureSession(with: configuration, options: options)
-    }
-    
-    /// Adds an ARReferenceImage to the configuration for the session to discover
-    func addReferenceImage(for image: UIImage, _ name: String = "", with physicalWidth: CGFloat, configuration: ARConfiguration = ARWorldTrackingConfiguration()) {
-        self.addReferenceImage(for: image, name, with: physicalWidth, configuration: configuration)
-    }
-}
-
 /// Protocol which defines the data a strategy needs to provide a `[ScreenAnnotation]`
 public protocol AnnotationLoadingStrategy {
     associatedtype CardItem: CardItemModel
     var cardContents: [CardItem] { get }
-    func load(with manager: ARManagement) throws -> [ScreenAnnotation<CardItem>]
+    func load(with manager: ARManager) throws -> [ScreenAnnotation<CardItem>]
 }
 
 internal protocol SceneLoadable where CardItem.ID: LosslessStringConvertible {
     associatedtype CardItem: CardItemModel
 
-    func syncCardContentsWithScene(manager: ARManagement,
+    func syncCardContentsWithScene(manager: ARManager,
                                    anchorImage: UIImage?,
                                    physicalWidth: CGFloat?,
                                    scene: HasAnchoring,
@@ -68,27 +38,15 @@ internal protocol SceneLoadable where CardItem.ID: LosslessStringConvertible {
 }
 
 extension SceneLoadable {
-    func syncCardContentsWithScene(manager: ARManagement,
+    func syncCardContentsWithScene(manager: ARManager,
                                    anchorImage: UIImage?,
                                    physicalWidth: CGFloat?,
                                    scene: HasAnchoring,
                                    cardContents: [CardItem]) throws -> [ScreenAnnotation<CardItem>]
     {
         var annotations = [ScreenAnnotation<CardItem>]()
-
-        // An image should use world tracking so we set the configuration to prevent automatic switching to Image Tracking
-        // Object Detection inherently uses world tracking so an automatic configuration can be used
-        switch scene.anchoring.target {
-        case .image:
-            guard let image = anchorImage, let width = physicalWidth else { return [] }
-            manager.sceneRoot = scene
-            manager.addReferenceImage(for: image, with: width)
-        case .object:
-            manager.setAutomaticConfiguration()
-            manager.addAnchor(for: scene)
-        default:
-            throw LoadingStrategyError.anchorTypeNotSupportedError
-        }
+        
+        try manager.setupScene(anchorImage: anchorImage, physicalWidth: physicalWidth, scene: scene)
 
         for cardItem in cardContents {
             guard let internalEntity = scene.findEntity(named: String(cardItem.id)) else {


### PR DESCRIPTION
Proposal: Refactor ARManger with compiler directives to be compatible on Simulator

- **Removed ARManagement Protocol**: Methods with compiler directives are not meaningful to test or use helper methods which can be tested. Testing the ARManager directly instead of mocking is feasible.
- Compiler Directives are encapsulated into the ARManager
- A fatalerror gives clear output of fioriarkit non-support when the session is configured/ran on the simulator
- The other compiler directives have no else block since they are unreachable because the fatalerror is thrown first
- minor improvements