### PR TITLE
feat: 🎸 Experimental Proposal for scanLabel Type Resolution

### DIFF
--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsServiceView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsServiceView.swift
@@ -24,9 +24,14 @@ struct ARCardsServiceView: View {
 
     var body: some View {
         ARAnnotationsView(arModel: arModel,
-                          cardAction: { id in
-                              // set the card action for id corresponding to the CardItemModel
-                              print(id)
+                          scanLabel: { guideImageState, anchorPosition in
+                              CustomScanView(guideImageState: guideImageState, position: anchorPosition)
+                          },
+                          cardLabel: { cardmodel, isSelected in
+                              CustomCardView(model: cardmodel, isSelected: isSelected)
+                          },
+                          markerLabel: { state, _ in
+                              CustomMarkerView(state: state)
                           })
             .onAppear(perform: loadInitialData)
     }

--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsViewBuilderContentView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsViewBuilderContentView.swift
@@ -13,8 +13,9 @@ struct ARCardsViewBuilderContentView: View {
     
     var body: some View {
         ARAnnotationsView(arModel: arModel,
-                          scanLabel: { guideImageState, anchorPosition in
-                              CustomScanView(guideImageState: guideImageState, position: anchorPosition)
+                          guideImage: UIImage(named: "qrImage"),
+                          scanLabel: { guideImage, anchorPosition in
+                              CustomScanWithDefaultImageView(guideImage: guideImage, position: anchorPosition)
                           },
                           cardLabel: { cardmodel, isSelected in
                               CustomCardView(model: cardmodel, isSelected: isSelected)
@@ -63,6 +64,43 @@ struct CustomScanView: View {
                         .scaledToFit()
                         .frame(width: 150)
                 }
+                
+                Text("Discover this Image!")
+                    .font(.system(size: 19))
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .padding()
+                    .background(Color.black.opacity(0.7))
+                    .cornerRadius(8)
+                    .padding(.bottom, 50)
+            }
+        }
+    }
+}
+
+struct CustomScanWithDefaultImageView: View {
+    var guideImage: UIImage
+    var position: CGPoint?
+    
+    var body: some View {
+        ZStack {
+            if let position = position {
+                Text("Discovered!")
+                    .font(.system(size: 17, weight: .bold))
+                    .foregroundColor(.black)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.green.opacity(0.7))
+                            .frame(width: 150, height: 150)
+                    )
+                    .position(position)
+            }
+            VStack(spacing: 15) {
+                Spacer()
+                Image(uiImage: guideImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 150)
                 
                 Text("Discover this Image!")
                     .font(.system(size: 19))

--- a/Sources/FioriAR/ARCards/RealityKit/LoadingStrategies/AnnotationLoadingStrategy.swift
+++ b/Sources/FioriAR/ARCards/RealityKit/LoadingStrategies/AnnotationLoadingStrategy.swift
@@ -8,8 +8,10 @@
 import ARKit
 import RealityKit
 
+public protocol LoadingStrategy {}
+
 /// Protocol which defines the data a strategy needs to provide a `[ScreenAnnotation]`
-public protocol AnnotationLoadingStrategy {
+public protocol AnnotationLoadingStrategy: LoadingStrategy {
     ///  associated type of this protocol needs to conform to `CardItemModel`
     associatedtype CardItem: CardItemModel
     /// cards content to be populated
@@ -19,7 +21,7 @@ public protocol AnnotationLoadingStrategy {
 }
 
 /// Protocol which defines the data an asynchronous strategy needs to provide a `[ScreenAnnotation]`
-public protocol AsyncAnnotationLoadingStrategy {
+public protocol AsyncAnnotationLoadingStrategy: LoadingStrategy {
     ///  associated type of this protocol needs to conform to `CardItemModel` and `Codable`
     associatedtype CardItem: CardItemModel, Codable
     /// load screen annotations and guideImage asynchronously

--- a/Sources/FioriAR/ARCards/ViewModels/ARAnnotationViewModel.swift
+++ b/Sources/FioriAR/ARCards/ViewModels/ARAnnotationViewModel.swift
@@ -23,7 +23,7 @@ open class ARAnnotationViewModel<CardItem: CardItemModel>: NSObject, ObservableO
     @Published public internal(set) var currentAnnotation: ScreenAnnotation<CardItem>?
     
     /// The guideImage for the scanLabel retrieved from the AnnotationLoadingStrategy
-    @Published internal var guideImage: GuideImageState = .notStarted
+    @Published internal var guideImageType: GuideItemModel?
     
     /// The position of the ARAnchor thats discovered
     @Published internal var anchorPosition: CGPoint?
@@ -88,16 +88,16 @@ open class ARAnnotationViewModel<CardItem: CardItemModel>: NSObject, ObservableO
     public func load<Strategy: AnnotationLoadingStrategy>(loadingStrategy: Strategy) throws where CardItem == Strategy.CardItem {
         let sceneData = try loadingStrategy.load(with: self.arManager)
         self.annotations = sceneData.annotations
-        self.guideImage = .finished(sceneData.guideImage ?? UIImage(systemName: "xmark.icloud")!)
+        self.guideImageType = sceneData.guideImage ?? UIImage(systemName: "xmark.icloud")!
         self.setSelectedAnnotation(for: self.annotations.first)
     }
     
     /// Loads an asynchronous strategy into the arModel and sets **annotations** member from the returned [ScreenAnnotation]
     public func loadAsync<Strategy: AsyncAnnotationLoadingStrategy>(loadingStrategy: Strategy) throws where CardItem == Strategy.CardItem {
-        try loadingStrategy.load(with: self.arManager, completionHandler: { annotations, guideImage in
+        try loadingStrategy.load(with: self.arManager, completionHandler: { annotations, guideImageState in
             DispatchQueue.main.async {
                 self.annotations = annotations
-                self.guideImage = guideImage
+                self.guideImageType = guideImageState
                 self.setSelectedAnnotation(for: self.annotations.first)
             }
         })


### PR DESCRIPTION
- Do Not Merge

**Problem Context:**
ARScanView in an asynchronous scenario needs to have an enum type to represent different states of the fetching process for the guide image. Early solution is to only have a GuideImageState type.

**Problem:**
However, when using a Custom ScanLabel the type of the ViewBuilder poses a problem if it is (GuideImageState) -> ... for synchronous scenarios it will also use this GuideImageState but an UIImage is guaranteed to be returned.

```swift
// May not be asynchronous so the enum is confusing and should be UIImage in this case
ARAnnotationsView(scanLabel: { guideImageState in 
})
```

A possible solution is type erase the scanLabel Closure parameter type:
Have the initializers resolve the type for a single viewBuilder.

```swift
public protocol GuideItemModel {}
extension UIImage: GuideItemModel {}
extension GuideImageState: GuideItemModel {}

struct ARAnnotationsView<Scan: View, GuideItem: GuideItemModel>: View {
    // arModel will return default image, either a UIImage or GuideImageState depending on sync or async
    let arModel = ARAnnotationViewModel()
    // image if developer wants to choose their own
    let guideImage: UIImage?

    let scanLabel: (GuideItem, CGPoint?) -> Scan
    
    var body: some View {
         // logic to determine if developer passed in their own image or if the viewModel is providing a default
         if let erasedGuideItem = ((guideImage as? GuideItem) ?? (arModel.guideImageType as? GuideItem)) {
             scanLabel(erasedGuideItem, arModel.anchorPosition)
         }
    }
}

public init(guideImage: UIImage? = nil,
           @ViewBuilder scanLabel: @escaping (UIImage, CGPoint?)) where GuideItem == UIImage
    {
        guideImage = guideImage
        self.scanLabel = scanLabel
    }
public init(@ViewBuilder scanLabel: @escaping (GuideImageState, CGPoint?) -> Scan) where GuideItem == GuideImageState
    {
        self.scanLabel = scanLabel
    }
```
```swift
Usage now can be both types:
ARAnnotationsView(scanLabel: { guideImageState in
})
ARAnnotationsView(scanLabel: { uiImage in
})
```
This will produce the appropriate type from the perspective of the developer

Cons:
- Testing further to prevent ambigious use of initializers
- The usage of these complex types conversions can be confusing to new readers

Follow up alternative:
- Using two ViewBuilders for the scanLabel one for sync and the other for async.