### PR TITLE
docs: ✏️ add FioriAR 2.0 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ You can choose one of the following package products to be added to your applica
 |FioriAR|You did not already embed binary frameworks from SAP BTP SDK for iOS|
 |FioriAR-requiresToEmbedXCFrameworks|You already embedded `SAPCommon` and `SAPFoundation` binary frameworks to your target|
 
+# Migration
+
+FioriAR 2.0 is NOT fully compatible with the previous version. However, the migration is not difficult. Please follow the [migration guide](https://github.com/SAP/cloud-sdk-ios-fioriarkit/wiki/FioriAR-2.0-Migration-Guide) when you prepare to upgrade FioriAR in your project.
+
 # AR Annotations
 
 https://user-images.githubusercontent.com/77754056/121744202-2ea88c80-cac8-11eb-811d-9c9edb6423fa.mp4


### PR DESCRIPTION
Hi Patrick,

I wrote a migration guide in the wiki (https://github.com/SAP/cloud-sdk-ios-fioriarkit/wiki/FioriAR-2.0-Migration-Guide) and linked it in the README. Can you check the migration guide please? 

I tried to focus on the most important breaking changes. We have more, e.g

- ViewBuilder for `scanView` expects an enum
- `AnnotationLoadingStrategy` load now returns a tuple
- `ARManagement` Protocol Removed
- Renamed `descriptionText` to `subtitle`
- Changed CardItemModel` Data Types

but I feel not everything has to be covered in the example as the majority of developers probably won't be affected. But we maybe should list them in the migration guide. I am eager to hear your opinion.

Kind regards,
Marco

